### PR TITLE
Fix keys with dots or dashs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ You can test if your yaml file will be readed correctly based on test folder.
 
 ## Known issues
 
-- Can't parse "some-property".
 - Can't parse a object list with first attribute like "- name: MyName". Must be down.
 - Object lists must be informed all attributes. Null must be "attr: ".
 

--- a/test/file.yml
+++ b/test/file.yml
@@ -35,6 +35,9 @@ complex_test:
 --
 more_tests:
   double_dashes: --ok
+  dot_start: .dot
+  some-propertie: some-propertie ok!
+  domain.com: domain.com ok!
   inline_comment: something #comment
   hash_commented: #hi
   comment_with_hash: an#hash #with an comment

--- a/test/test.sh
+++ b/test/test.sh
@@ -41,6 +41,9 @@ function test_list() {
 test_list "$complex_test_simple_obj_a_list" &&
 
 [ "$more_tests_double_dashes" = "--ok" ] &&
+[ "$more_tests_dot_start" = ".dot" ] &&
+[ "$more_tests_some_propertie" = "some-propertie ok!" ] &&
+[ "$more_tests_domain_com" = "domain.com ok!" ] &&
 [ "$more_tests_inline_comment" = "something" ] &&
 [ "$more_tests_comment_with_hash" = "an#hash" ] &&
 [ "$more_tests_hash" = "a#hash" ] &&

--- a/yaml.sh
+++ b/yaml.sh
@@ -10,7 +10,7 @@ function parse_yaml() {
     local fs
 
     s='[[:space:]]*'
-    w='[a-zA-Z0-9_]*'
+    w='[a-zA-Z0-9_.-]*'
     fs="$(echo @|tr @ '\034')"
 
     (
@@ -18,6 +18,7 @@ function parse_yaml() {
             -e "/#.*[\"\']/!s| #.*||g; /^#/s|#.*||g;" \
             -e  "s|^\($s\)\($w\)$s:$s\"\(.*\)\"$s\$|\1$fs\2$fs\3|p" \
             -e "s|^\($s\)\($w\)$s[:-]$s\(.*\)$s\$|\1$fs\2$fs\3|p" |
+
         awk -F"$fs" '{
             indent = length($1)/2;
             if (length($2) == 0) { conj[indent]="+";} else {conj[indent]="";}
@@ -28,7 +29,11 @@ function parse_yaml() {
                     printf("%s%s%s%s=(\"%s\")\n", "'"$prefix"'",vn, $2, conj[indent-1],$3);
                 }
             }' |
-        sed 's/_=/+=/g'
+            
+        sed -e 's/_=/+=/g' \
+            -e '/\..*=/s|\.|_|' \
+            -e '/\-.*=/s|\-|_|'
+
     ) < "$yaml_file"
 }
 


### PR DESCRIPTION
A known issue that can't parse keys with dash.

As @HowardMei said on #3, dots is a problem too. I did find a solution that can fix more than dashs or dots, if needed.

* Add what need on `w='[a-zA-Z0-9_.-]*'`, before the dash.
* Then on final sed add a new replace for it like `-e '/\-.*=/s|\-|_|'`.
