### PR TITLE
Fix attributes of lists on first line

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ You can test if your yaml file will be readed correctly based on test folder.
 
 ## Known issues
 
-- Can't parse a object list with first attribute like "- name: MyName". Must be down.
 - Object lists must be informed all attributes. Null must be "attr: ".
 
 ## Credits

--- a/test/file.yml
+++ b/test/file.yml
@@ -20,6 +20,12 @@ complex_test:
   simple_obj:
     attr: "value"
     other_attr: other "value"
+    chaos_list:
+      - attr: value1
+        otherv: value1v
+      -
+        attr: value2
+        otherv: "value2v"
     a_list:
       - 0
       - 1

--- a/test/test.sh
+++ b/test/test.sh
@@ -56,6 +56,11 @@ function test_list() {
 [ "$complex_test_simple_obj_attr" = "\"value\"" ] &&
 [ "$complex_test_simple_obj_other_attr" = "other \"value\"" ] &&
 
+[ "${complex_test_simple_obj_chaos_list__attr[0]}" = "value1" ] &&
+[ "${complex_test_simple_obj_chaos_list__otherv[0]}" = "value1v" ] &&
+[ "${complex_test_simple_obj_chaos_list__attr[1]}" = "value2" ] &&
+[ "${complex_test_simple_obj_chaos_list__otherv[1]}" = "\"value2v\"" ] &&
+
 test_list "${complex_test_simple_obj_a_list[*]}" &&
 
 [ "$more_tests_double_dashes" = "--ok" ] &&

--- a/yaml.sh
+++ b/yaml.sh
@@ -13,34 +13,34 @@ function parse_yaml() {
     w='[a-zA-Z0-9_.-]*'
     fs="$(echo @|tr @ '\034')"
 
-    (
-        sed -ne '/^--/s|--||g; s|\"|\\\"|g; s/\s*$//g;' \
-            -e "/#.*[\"\']/!s| #.*||g; /^#/s|#.*||g;" \
-            -e  "s|^\($s\)\($w\)$s:$s\"\(.*\)\"$s\$|\1$fs\2$fs\3|p" \
-            -e "s|^\($s\)\($w\)$s[:-]$s\(.*\)$s\$|\1$fs\2$fs\3|p" |
+    sed -e "/- [^\"][^\'].*:/s|\([ ]*\)- \($s\)|\1-\n  \1\2|g" "$yaml_file" |
 
-        awk -F"$fs" '{
-            indent = length($1)/2;
-            if (length($2) == 0) { conj[indent]="+";} else {conj[indent]="";}
-            vname[indent] = $2;
-            for (i in vname) {if (i > indent) {delete vname[i]}}
-                if (length($3) > 0) {
-                    vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
-                    printf("%s%s%s%s=(\"%s\")\n", "'"$prefix"'",vn, $2, conj[indent-1],$3);
-                }
-            }' |
-            
-        sed -e 's/_=/+=/g' |
-        awk 'BEGIN {
-                 FS="=";
-                 OFS="="
-             }
-             /(-|\.).*=/ {
-                 gsub("-|\\.", "_", $1)
-             }
-             { print }'
+    sed -ne '/^--/s|--||g; s|\"|\\\"|g; s/\s*$//g;' \
+        -e "/#.*[\"\']/!s| #.*||g; /^#/s|#.*||g;" \
+        -e "s|^\($s\)\($w\)$s:$s\"\(.*\)\"$s\$|\1$fs\2$fs\3|p" \
+        -e "s|^\($s\)\($w\)$s[:-]$s\(.*\)$s\$|\1$fs\2$fs\3|p" |
 
-    ) < "$yaml_file"
+    awk -F"$fs" '{
+        indent = length($1)/2;
+        if (length($2) == 0) { conj[indent]="+";} else {conj[indent]="";}
+        vname[indent] = $2;
+        for (i in vname) {if (i > indent) {delete vname[i]}}
+            if (length($3) > 0) {
+                vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
+                printf("%s%s%s%s=(\"%s\")\n", "'"$prefix"'",vn, $2, conj[indent-1],$3);
+            }
+        }' |
+        
+    sed -e 's/_=/+=/g' |
+    
+    awk 'BEGIN {
+             FS="=";
+             OFS="="
+         }
+         /(-|\.).*=/ {
+             gsub("-|\\.", "_", $1)
+         }
+         { print }'
 }
 
 function create_variables() {


### PR DESCRIPTION
Fix bug #9 

When a list of objects have the first attribute on same line of starter
list, this item was created wrong.

Sample: - attr: value
Expected: object__attr[0] = "value"
Received: object[0] = "attr: value"