### PR TITLE
Added function to unset existing variables with same name

### DIFF
--- a/script/yaml.sh
+++ b/script/yaml.sh
@@ -46,8 +46,23 @@ parse_yaml() {
     ) < "$yaml_file"
 }
 
+unset_variables() {
+  # Pulls out the variable names and unsets them.
+  local variable_string="$@"
+  unset variables
+  variables=()
+  for variable in ${variable_string[@]}; do
+    variables+=($(echo $variable | grep '=' | sed 's/=.*//' | sed 's/+.*//'))
+  done
+  for variable in ${variables[@]}; do
+    unset $variable
+  done
+}
+
 create_variables() {
     local yaml_file="$1"
     local prefix="$2"
-    eval "$(parse_yaml "$yaml_file" "$prefix")"
+    local yaml_string="$(parse_yaml "$yaml_file" "$prefix")"
+    unset_variables ${yaml_string[@]}
+    eval "${yaml_string}"
 }


### PR DESCRIPTION
I added a function `unset_variables` and call to that function prior to variable creation. I found that especially arrays were sticky and elements were being added to existing arrays with the same name instead of creating fresh ones. This solves that.

The function parses the string returned by `parse_yaml`, pulls out the variable names, and then unsets each one.

# What it's changing and/or adding?
* Function to unset any existing variables with the same name.

# What OS and/or Bash version it happens? (fix only)
* Mac OS and Linux (tested on CentOS)

# An example of Yaml file to validate
Tested with `file.yml` and `test.sh` from master repository. Issue was only arising when a yaml file was loaded programmatically twice within a shell session, causing all arrays to duplicate

