### PR TITLE
Escape dollar signs from YAML values

### DIFF
--- a/script/yaml.sh
+++ b/script/yaml.sh
@@ -29,7 +29,7 @@ parse_yaml() {
             for (i in vname) {if (i > indent) {delete vname[i]}}
                 if (length($3) > 0) {
                     vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
-                    printf("%s%s%s%s=(\"%s\")\n", "'"$prefix"'",vn, $2, conj[indent-1],$3);
+                    printf("%s%s%s%s=(\"%s\")\n", "'"$prefix"'",vn, $2, conj[indent-1], gensub("\\$", "\\\\$", "g", $3));
                 }
             }' |
 

--- a/test/file.yml
+++ b/test/file.yml
@@ -64,3 +64,4 @@ more_tests:
   a.multi.dot.property: result.is=OK
   a-property-that-has-quite-a-number-of-dashes: result-is=OK
   a-property-that-has-dashes.and.dots: result-is.absolutely=fine.and-perfect
+  value-with-dollar-signs: I know your $HOME. I live at $(pwd)

--- a/test/test.sh
+++ b/test/test.sh
@@ -87,6 +87,7 @@ test_list "${complex_test_simple_obj_a_list[*]}" &&
 [ "$more_tests_a_multi_dot_property" = "result.is=OK" ] &&
 [ "$more_tests_a_property_that_has_quite_a_number_of_dashes" = "result-is=OK" ] &&
 [ "$more_tests_a_property_that_has_dashes_and_dots" = "result-is.absolutely=fine.and-perfect" ] &&
+[ "$more_tests_value_with_dollar_signs" = "I know your \$HOME. I live at \$(pwd)" ] &&
 
 # Output result
 echo "Tests ok!" && exit 0 || echo "Error on execute tests!" && exit 1


### PR DESCRIPTION
# What it's changing and/or adding?

Adds a escaping on dollar signs so that `eval` doesn't parse them as shell variables or commands. 

This fixes a potential security vulnerability allowing malicious users to execute code in specially crafted YAML files.

# What OS and/or Bash version it happens? (fix only)

All

# An example of Yaml file to validate

Included in the tests.
