### PR TITLE
Always use the latest Shellcheck and find .sh files automatically

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,9 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-            SCVER="0.7.1"
-            wget -qO- https://github.com/koalaman/shellcheck/releases/download/v${SCVER}/shellcheck-v${SCVER}.linux.x86_64.tar.xz | tar -xJf -
-            shellcheck-v${SCVER}/shellcheck ./script/yaml.sh
+            sudo apt-get -y update && sudo apt-get -y install shellcheck
+            find $GITHUB_WORKSPACE -type f -and \( -name "*.sh" \) | xargs shellcheck
 
   editorconfig:
     name: Editorconfig


### PR DESCRIPTION
This installs the latest shellcheck version available and searches the repo for files ending with `.sh`.
It ensures that any shell scripts that might get added in the future are automatically linted as well.