### PR TITLE
Add support for bpkg and run from command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+PREFIX ?= /usr/local
+BINDIR ?= $(PREFIX)/bin
+
+install:
+	$(info Installing the library to $(BINDIR))
+	@install -Dm755 script/yaml.sh  $(BINDIR)/yaml.sh
+
+uninstall:
+	$(info Removing library from $(BINDIR))
+	@rm -f $(BINDIR)/yaml.sh
+
+.PHONY: install uninstall

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "bash-yaml",
+    "version": "0.0.1",
+    "description": "Bash script to read a Yaml file and create variables.",
+    "global": "false",
+    "install": "make install",
+    "scripts": [
+        "bin/yaml.sh"
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
     "global": "false",
     "install": "make install",
     "scripts": [
-        "bin/yaml.sh"
+        "yaml.sh"
     ]
 }

--- a/script/yaml.sh
+++ b/script/yaml.sh
@@ -71,6 +71,6 @@ create_variables() {
 
 # Execute parse_yaml() direct from command line
 
-if [ "x" != "x${1}" ]; then
+if [ "x" != "x${1}" ] && [ "x--debug" != "x${1}" ]; then
     parse_yaml "${1}" "${2}"
 fi

--- a/script/yaml.sh
+++ b/script/yaml.sh
@@ -12,18 +12,16 @@ parse_yaml() {
 
     s='[[:space:]]*'
     w='[a-zA-Z0-9_.-]*'
-    fs="$(echo @|tr @ '\034')"
+    fs="$(echo @ | tr @ '\034')"
 
     (
         sed -e '/- [^\“]'"[^\']"'.*: /s|\([ ]*\)- \([[:space:]]*\)|\1-\'$'\n''  \1\2|g' |
-
-        sed -ne '/^--/s|--||g; s|\"|\\\"|g; s/[[:space:]]*$//g;' \
-            -e 's/\$/\\\$/g' \
-            -e "/#.*[\"\']/!s| #.*||g; /^#/s|#.*||g;" \
-            -e "s|^\($s\)\($w\)$s:$s\"\(.*\)\"$s\$|\1$fs\2$fs\3|p" \
-            -e "s|^\($s\)\($w\)${s}[:-]$s\(.*\)$s\$|\1$fs\2$fs\3|p" |
-
-        awk -F"$fs" '{
+            sed -ne '/^--/s|--||g; s|\"|\\\"|g; s/[[:space:]]*$//g;' \
+                -e 's/\$/\\\$/g' \
+                -e "/#.*[\"\']/!s| #.*||g; /^#/s|#.*||g;" \
+                -e "s|^\($s\)\($w\)$s:$s\"\(.*\)\"$s\$|\1$fs\2$fs\3|p" \
+                -e "s|^\($s\)\($w\)${s}[:-]$s\(.*\)$s\$|\1$fs\2$fs\3|p" |
+            awk -F"$fs" '{
             indent = length($1)/2;
             if (length($2) == 0) { conj[indent]="+";} else {conj[indent]="";}
             vname[indent] = $2;
@@ -33,10 +31,8 @@ parse_yaml() {
                     printf("%s%s%s%s=(\"%s\")\n", "'"$prefix"'",vn, $2, conj[indent-1], $3);
                 }
             }' |
-
-        sed -e 's/_=/+=/g' |
-
-        awk 'BEGIN {
+            sed -e 's/_=/+=/g' |
+            awk 'BEGIN {
                 FS="=";
                 OFS="="
             }
@@ -44,24 +40,24 @@ parse_yaml() {
                 gsub("-|\\.", "_", $1)
             }
             { print }'
-    ) < "$yaml_file"
+    ) <"$yaml_file"
 }
 
 unset_variables() {
-  # Pulls out the variable names and unsets them.
-  #shellcheck disable=SC2048,SC2206 #Permit variables without quotes
-  local variable_string=($*)
-  unset variables
-  variables=()
-  for variable in "${variable_string[@]}" ; do
-    tmpvar=$(echo "$variable" | grep '=' | sed 's/=.*//' | sed 's/+.*//')
-    variables+=("$tmpvar")
-  done
-  for variable in "${variables[@]}"; do
-  if [ -n "$variable" ] ; then
-    unset "$variable"
-  fi
-  done
+    # Pulls out the variable names and unsets them.
+    #shellcheck disable=SC2048,SC2206 #Permit variables without quotes
+    local variable_string=($*)
+    unset variables
+    variables=()
+    for variable in "${variable_string[@]}"; do
+        tmpvar=$(echo "$variable" | grep '=' | sed 's/=.*//' | sed 's/+.*//')
+        variables+=("$tmpvar")
+    done
+    for variable in "${variables[@]}"; do
+        if [ -n "$variable" ]; then
+            unset "$variable"
+        fi
+    done
 }
 
 create_variables() {
@@ -72,3 +68,9 @@ create_variables() {
     unset_variables "${yaml_string}"
     eval "${yaml_string}"
 }
+
+# Execute parse_yaml() direct from command line
+
+if [ "x" != "x${1}" ]; then
+    parse_yaml "${1}" "${2}"
+fi


### PR DESCRIPTION
# What it's changing and/or adding?
1. package.json (the name will change to bpkg.json in the next version.
2. Makefile do install (mandatory for bpkg packages)
Bpkg is a package manager for shell scripts like npm and composer. Is a really nice way to keep scripts updated.
3. Added the ability to execute parse_yaml direct from command-line without sourcing the file first. If the program are executed with some parameter (except --debug), it executes parse_yaml() with the parameters sent.

I didn't change the tests and the are still passing.


# What OS and/or Bash version it happens? (fix only)

# An example of Yaml file to validate

