### PR TITLE
Make it work with `set -u`

### DIFF
--- a/script/yaml.sh
+++ b/script/yaml.sh
@@ -71,6 +71,6 @@ create_variables() {
 
 # Execute parse_yaml() direct from command line
 
-if [ "x" != "x${1}" ] && [ "x--debug" != "x${1}" ]; then
-    parse_yaml "${1}" "${2}"
+if [ "x" != "x${1:-}" ] && [ "x--debug" != "x${1:-}" ]; then
+    parse_yaml "${1}" "${2:-}"
 fi

--- a/script/yaml.sh
+++ b/script/yaml.sh
@@ -5,7 +5,7 @@
 
 parse_yaml() {
     local yaml_file=$1
-    local prefix=$2
+    local prefix=${2:-}
     local s
     local w
     local fs


### PR DESCRIPTION
# Intro

From the [man page of `set`](http://linuxcommand.org/lc3_man_pages/seth.html) in BASH:

> -u  Treat unset variables as an error when substituting.

In other words - like many of the other `set` parameters - this allows a script to fail-fast.
Using when editing the script in a modern editor/IDE, also enables linting for those errors.

# What it's changing and/or adding?

Where `$1` and `$2` are used and they might be unset, this change replaces them with `${1:-}` and `${2:-}`,
which means "use $1 if set, else the empty string" 

# What OS and/or Bash version it happens? (fix only)

All, if `set -u` is used.